### PR TITLE
Populate response on errors as a POJO

### DIFF
--- a/src/check-status.js
+++ b/src/check-status.js
@@ -14,14 +14,16 @@ function parseJSONError(response) {
 		response
 			.json()
 			.then(data => {
-				// replace the existing body with the JSON response
-				response.jsonBody = data;
-
 				let msg = parseErrorMessageFromData(data);
 				if (!msg) msg = response.statusText;
 
 				let error = new Error(msg);
-				error.response = response;
+				error.response = {
+					status: response.status,
+					type: response.type,
+					url: response.url,
+					body: data
+				};
 
 				reject(error);
 			})

--- a/test/batch-fetching.js
+++ b/test/batch-fetching.js
@@ -205,7 +205,6 @@ describe("Batch fetching", function() {
 			it("should populate the response from the fetch result", function() {
 				expect(this.homerFailure.response).to.be.ok;
 				expect(this.homerFailure.response.status).to.equal(500);
-				expect(this.homerFailure.response.statusText).to.equal("Server Error");
 			});
 		});
 	});
@@ -287,7 +286,6 @@ describe("Batch fetching", function() {
 
 				expect(this.failure.response).to.be.ok;
 				expect(this.failure.response.status).to.equal(500);
-				expect(this.failure.response.statusText).to.equal("Server Error");
 			});
 		});
 	});
@@ -450,7 +448,6 @@ describe("Batch fetching", function() {
 				expect(this.margeFailure).to.be.ok;
 				expect(this.margeFailure.response).to.be.ok;
 				expect(this.margeFailure.response.status).to.equal(404);
-				expect(this.margeFailure.response.statusText).to.equal("Not Found");
 			});
 		});
 
@@ -518,7 +515,6 @@ describe("Batch fetching", function() {
 			it("should populate the response from the fetch result", function() {
 				expect(this.bartFailure.response).to.be.ok;
 				expect(this.bartFailure.response.status).to.equal(404);
-				expect(this.bartFailure.response.statusText).to.equal("Not Found");
 			});
 		});
 	});

--- a/test/parsing-response.js
+++ b/test/parsing-response.js
@@ -144,9 +144,7 @@ describe("Parsing Responses", function() {
 
 			shouldRejectWithError(500);
 
-			it("should use the exception message as the error message", function(
-				done
-			) {
+			it("should use the exception message as the error message", function(done) {
 				this.result.catch(err => {
 					expect(err.message).to.equal(
 						"Cannot do the thing you wanted to do because of some important reason."
@@ -176,9 +174,7 @@ describe("Parsing Responses", function() {
 
 			shouldRejectWithError(500);
 
-			it("should use the exception message as the error message", function(
-				done
-			) {
+			it("should use the exception message as the error message", function(done) {
 				this.result.catch(err => {
 					expect(err.message).to.equal(
 						"Cannot do the thing you wanted to do because of some important reason."
@@ -220,9 +216,7 @@ describe("Parsing Responses", function() {
 
 			shouldRejectWithError(500);
 
-			it("should use the inner-most exception message as the error message", function(
-				done
-			) {
+			it("should use the inner-most exception message as the error message", function(done) {
 				this.result.catch(err => {
 					expect(err.message).to.equal(
 						"Cannot do the thing you wanted to do because of some important reason."
@@ -262,9 +256,7 @@ describe("Parsing Responses", function() {
 
 			shouldRejectWithError(500);
 
-			it("should use the inner-most exception message as the error message", function(
-				done
-			) {
+			it("should use the inner-most exception message as the error message", function(done) {
 				this.result.catch(err => {
 					expect(err.message).to.equal("Cannot do the thing");
 					done();
@@ -302,9 +294,7 @@ describe("Parsing Responses", function() {
 
 			shouldRejectWithError(500);
 
-			it("should use the inner-most exception message as the error message", function(
-				done
-			) {
+			it("should use the inner-most exception message as the error message", function(done) {
 				this.result.catch(err => {
 					expect(err.message).to.equal("Not a useless message");
 					done();


### PR DESCRIPTION
Need to be able to log failed fetch responses and calling `JSON.stringify` on a `Response` object yields nothing.

See [here for more context](http://www.allannienhuis.com/archives/2015/02/04/beware-json-stringify/).

This potentially a breaking change, although, probably not since it is copying all the relevant stuff over.